### PR TITLE
Fix build script variable

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,7 @@ function Get-NuGet {
 $nuget = Get-NuGet
 & $nuget restore "$PSScriptRoot/AudioVisualiser.sln"
 
-msbuildArgs = @(
+$msbuildArgs = @(
     'AudioVisualiser.sln',
     "/p:Configuration=$Configuration",
     "/p:Platform=$Platform"


### PR DESCRIPTION
## Summary
- fix variable name in build.ps1

## Testing
- `pwsh -ExecutionPolicy Bypass -File build.ps1` *(fails: command not found)*
- `powershell -ExecutionPolicy Bypass -File build.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840297c4f70832b8ca492fa437b52d1